### PR TITLE
Issue #85 (BUG) : Fix Join Channel Endpoint with Authentication and Serialization

### DIFF
--- a/backend/channels/tests.py
+++ b/backend/channels/tests.py
@@ -12,7 +12,6 @@ User = get_user_model()
 class ChannelListViewTest(APITestCase):
 
     def setUp(self):
-        """Set up test data."""
         print("\nSetting up test data...")
         self.user = User.objects.create_user(username="testuser", password="testpassword")
         self.client.force_authenticate(user=self.user)
@@ -22,7 +21,6 @@ class ChannelListViewTest(APITestCase):
         print("Test data created: 2 channels and 1 test user.")
 
     def test_channel_list_authenticated(self):
-        """Test that an authenticated user can get the channel list."""
         print("\nRunning test: test_channel_list_authenticated")
         response = self.client.get("/api/channels/channel-list/")
         print(f"Response status code: {response.status_code}")
@@ -33,7 +31,6 @@ class ChannelListViewTest(APITestCase):
         print("Authenticated user successfully retrieved the channel list.")
 
     def test_channel_list_unauthenticated(self):
-        """Test that an unauthenticated user gets a 403 Forbidden response."""
         print("\nRunning test: test_channel_list_unauthenticated")
         self.client.logout()
         response = self.client.get("/api/channels/channel-list/")
@@ -45,33 +42,29 @@ class ChannelListViewTest(APITestCase):
 class JoinChannelTest(TestCase):
 
     def setUp(self):
-        # Create a channel called 'Test Channel' for the test
         self.channel_name = 'Test Channel5'
         self.channel = Channel.objects.create(name=self.channel_name)
-        print(f"Created channel: {self.channel_name}")  # Print statement to show channel creation
+        print(f"Created channel: {self.channel_name}")  
 
     def test_join_channel(self):
-        # Create a unique username
         username = f"user_{get_random_string(length=8)}"
         user = get_user_model().objects.create_user(username=username, password='password')
-        print(f"Created user: {username}")  # Print statement to show user creation
+        print(f"Created user: {username}")  
 
-        # Specify the existing channel name
         channel_name = 'Test Channel5'
 
         try:
-            # Get the existing channel
+           
             channel = Channel.objects.get(name=channel_name)
-            print(f"Retrieved channel: {channel.name}")  # Print to confirm channel retrieval
+            print(f"Retrieved channel: {channel.name}")  
 
-            # Check if the user is already a member of the channel
             if user in channel.members.all():
-                print(f"User {user.username} is already a member of {channel.name}.")  # Print if user is a member
+                print(f"User {user.username} is already a member of {channel.name}.")  
                 self.assertIn(user, channel.members.all())
             else:
-                # Add the user to the channel
+
                 channel.members.add(user)
-                print(f"User {user.username} added to channel {channel.name}.")  # Print when user is added
+                print(f"User {user.username} added to channel {channel.name}.") 
                 self.assertIn(user, channel.members.all())
         except Channel.DoesNotExist:
             self.fail(f"Channel '{channel_name}' does not exist.")

--- a/backend/channels/tests.py
+++ b/backend/channels/tests.py
@@ -3,8 +3,6 @@ from rest_framework import status
 from django.contrib.auth import get_user_model
 from .models import Channel
 from django.test import TestCase
-from django.contrib.auth import get_user_model
-from channels.models import Channel
 from django.utils.crypto import get_random_string
 
 User = get_user_model()

--- a/backend/channels/views.py
+++ b/backend/channels/views.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.shortcuts import render, get_object_or_404
 from django.http import JsonResponse
 from django.contrib.auth.models import User
-from django.contrib.auth.decorators import login_required
 
 from .models import Channel, Message
 from .serializers import MessageSerializer

--- a/backend/channels/views.py
+++ b/backend/channels/views.py
@@ -34,14 +34,12 @@ def join_channel(request, channel_id):
         channel = get_object_or_404(Channel, id=channel_id)
         user = request.user
 
-        # Check if user is already a member
+        
         if user in channel.members.all():
             return Response({'message': 'User is already a member'}, status=200)
 
-        # Add user to the channel
         channel.members.add(user)
         
-        # Serialize updated channel with member details
         serializer = ChannelSerializer(channel, context={"request": request})
 
         return Response({
@@ -57,7 +55,6 @@ def join_channel(request, channel_id):
 def list_messages_in_channel(request, channel_id):
     if request.method == 'GET':
         try:
-            # If the Channel does not exist, the user should be redirected to a 404 page
             channel = Channel.objects.get(id=channel_id)
         except Channel.DoesNotExist:
             return JsonResponse({'error': 'Channel not found'}, status=404)


### PR DESCRIPTION
**Description**
The 404 error on the **join channel** endpoint was caused by the use of the `@login_required` decorator, which is incompatible with Django REST framework's API views. To resolve this issue, I refactored the endpoint to use the `@api_view(["POST"])` decorator along with `@permission_classes([IsAuthenticated])`, ensuring proper authentication and permission handling.

The updated view:
- Allows only **authenticated users** to join channels.
- Returns a **200 OK** response when the user successfully joins the channel.
- Provides **appropriate error messages** for invalid requests (e.g., non-existent channels or duplicate membership).
- Serializes the updated channel data, including member details, in the response.


### Steps to Test the Join Channel Endpoint with Postman

1. **Start the Server**
```bash
python manage.py runserver
```

2. **Generate an Access Token from Django Admin**
   - Go to the **Django admin panel** (`http://127.0.0.1:8000/admin/`).
   - Navigate to **Token → Add Token**.
   - Select the user you want to generate a token for.
   - Save and copy the **token** that appears.

3. **Open Postman**  
   Launch Postman and create a new **POST** request.

4. **Set up the Request**
   - **URL:** `http://127.0.0.1:8000/api/channels/join/<channel_id>/`
   - Replace `<channel_id>` with the actual channel ID you want to join.

5. **Add Authorization in the Headers**
   - In **Headers**, add the following:
     - **Key:** `Authorization`
     - **Value:** `Token <token_value>`  
     (Replace `<token_value>` with the token you copied earlier.)

6. **Send the Request**
   - Click **Send** in Postman.

---

### Expected Responses:

- **Valid Request:**  
    If the user is successfully added to the channel, you should get a **200 OK** response similar to this example:
    ```json
    {
      "message": "Successfully joined the channel",
      "channel": {
        "id": 2,
        "name": "Channel 2",
        "picture": null,
        "members": [
          2,
          3,
          5
        ]
      }
    }
    ```

- **User Already a Member:**  
    If the user is already a member of the channel, you will get a **200 OK** response with the message:
    ```json
    {
      "message": "User is already a member"
    }
    ```

- **Invalid Channel ID:**  
    If the channel doesn't exist, you'll get a **404 Not Found** response:
    ```json
    {
    "error": "No Channel matches the given query."
    }
    ```

- **Unauthenticated User:**  
    If the token is missing or invalid, you'll get a **401 Unauthorized** response:
    ```json
    {
      "detail": "Authentication credentials were not provided."
    }
    ```






