### PR TITLE
Issue #100: Implement concepts of user roles with Role-Based Permissions

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -2,10 +2,12 @@ from django.db import models
 from django.contrib.auth.models import AbstractUser
 
 class User(AbstractUser):
-    # AbstractUser class has username and password fields as required
     POSSIBLE_ROLES = (
         ('admin', 'Admin'),
         ('member', 'Member'),
     )
     role = models.CharField(max_length=6, choices=POSSIBLE_ROLES, default='member')
     profile_picture = models.ImageField(upload_to='profile_pictures/', null=True, blank=True)
+
+    def is_admin(self):
+        return self.role == 'admin'

--- a/backend/channels/models.py
+++ b/backend/channels/models.py
@@ -9,6 +9,9 @@ class Channel(models.Model):
     
     def __str__(self):
         return self.name
+    
+    def is_member(self, user):
+        return self.members.filter(id=user.id).exists()
 
 class Message(models.Model):
     channel = models.ForeignKey(Channel, on_delete=models.CASCADE, related_name="messages")

--- a/backend/channels/models.py
+++ b/backend/channels/models.py
@@ -21,3 +21,6 @@ class Message(models.Model):
     
     def __str__(self):
         return f"{self.user.username}: {self.content[:20]}"
+    
+    def can_delete(self, user):
+        return user.is_admin()

--- a/backend/channels/urls.py
+++ b/backend/channels/urls.py
@@ -10,4 +10,7 @@ urlpatterns = [
     path('join/<int:channel_id>/', views.join_channel, name='join-channel'),
     path('<int:channel_id>/messages/', list_messages_in_channel, name='message-list'),
     path('create/', views.create_channel, name='create-channel'),
+    #path('delete/<int:channel_id>/', views.delete_channel, name='delete-channel'),
+    #path('message/delete/<int:message_id>/', views.delete_message, name='delete-message'),
 ]
+

--- a/backend/channels/views.py
+++ b/backend/channels/views.py
@@ -37,7 +37,6 @@ def join_channel(request, channel_id):
             return Response({'message': 'User is already a member'}, status=200)
 
         channel.members.add(user)
-        
         serializer = ChannelSerializer(channel, context={"request": request})
 
         return Response({
@@ -64,13 +63,43 @@ def list_messages_in_channel(request, channel_id):
         return JsonResponse({'messages': serializer.data}, status=200)
     else:
         return JsonResponse({"error": "Method not allowed"}, status=405)
-    
+
 
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def create_channel(request):
+    if not request.user.is_admin():
+        return Response({"error": "Only admins can create channels"}, status=403)
+    
     serializer = ChannelSerializer(data=request.data, context={"request": request})
     if serializer.is_valid():
         channel = serializer.save()
         return Response(ChannelSerializer(channel, context={"request": request}).data, status=201)
     return Response(serializer.errors, status=400)
+
+
+
+
+#example of delete channel (But pamela will do it probably)
+
+#@api_view(["DELETE"])
+#@permission_classes([IsAuthenticated])
+#def delete_channel(request, channel_id):
+#    if not request.user.is_admin():
+#        return Response({"error": "Only admins can delete channels"}, status=403)
+#    
+#    channel = get_object_or_404(Channel, id=channel_id)
+#    channel.delete()
+#    return Response({"message": "Channel deleted successfully"}, status=204)
+
+
+#exmaple of delete message
+#@api_view(["DELETE"])
+#@permission_classes([IsAuthenticated])
+#def delete_message(request, message_id):
+#    message = get_object_or_404(Message, id=message_id)
+#    if not message.can_delete(request.user):
+#        return Response({"error": "You do not have permission to delete this message"}, status=403)
+#    
+#    message.delete()
+#    return Response({"message": "Message deleted successfully"}, status=204)


### PR DESCRIPTION
**Description:**
This PR introduces user permissions to restrict access to certain actions based on user roles (admin/member). The changes ensure that:
1. **Admins** can:
   - Create and delete channels.
   - Moderate messages (delete any message).
2. **Members** can:
   - Join channels.
   - Send and view messages.

**Changes Included:**
1. **Models:**
   - Added helper methods (`is_admin`, `is_member`, `can_delete`) to the `User`, `Channel`, and `Message` models for permission checks.
2. **Views:**
   - Added permission checks in `create_channel`, `join_channel`, and `list_messages_in_channel`.
3. **Serializers:**
   - Updated `ChannelSerializer` to restrict modifications to admins only.
